### PR TITLE
/rest/events?since=... needs more than 60s proxy read timeout

### DIFF
--- a/overlay/usr/local/etc/nginx/nginx.conf
+++ b/overlay/usr/local/etc/nginx/nginx.conf
@@ -89,6 +89,7 @@ http {
 	  proxy_set_header        X-Real-IP $remote_addr;
   	  proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
   	  proxy_set_header        X-Forwarded-Proto $scheme;
+	  proxy_read_timeout      70s;
   	  proxy_pass              http://localhost:8384/;
         }
     }


### PR DESCRIPTION
Every now and then the GUI complains that the connection is broken. The default timeout value of `/rest/events?since=...` is 60 s and the default of `proxy_read_timout` in NGINX is also 60 s. So sometimes NGINX returns an error after 60 s because Syncthing has not answered in time. Increasing the value for `proxy_read_timeout` prevents this.