### PR TITLE
switch proxy_http_version config for keepalive

### DIFF
--- a/overlay/usr/local/etc/nginx/nginx.conf
+++ b/overlay/usr/local/etc/nginx/nginx.conf
@@ -84,12 +84,14 @@ http {
         #    deny  all;
         #}
 
-	location /syncthing/ {
-	  proxy_set_header        Host localhost;
-	  proxy_set_header        X-Real-IP $remote_addr;
-  	  proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
-  	  proxy_set_header        X-Forwarded-Proto $scheme;
-  	  proxy_pass              http://localhost:8384/;
+        location /syncthing/ {
+            proxy_http_version      1.1;
+            proxy_set_header        Connection "";
+            proxy_set_header        Host localhost;
+            proxy_set_header        X-Real-IP $remote_addr;
+            proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header        X-Forwarded-Proto $scheme;
+            proxy_pass              http://localhost:8384/;
         }
     }
 


### PR DESCRIPTION
  * see https://nginx.org/en/docs/http/ngx_http_upstream_module.html#keepalive#
    "For HTTP, the proxy_http_version directive should be set to “1.1”
    and the “Connection” header field should be cleared"